### PR TITLE
Fix trailing return type for iterator_interface comparison operators

### DIFF
--- a/include/boost/stl_interfaces/iterator_interface.hpp
+++ b/include/boost/stl_interfaces/iterator_interface.hpp
@@ -450,7 +450,7 @@ namespace boost { namespace stl_interfaces { inline namespace v1 {
     operator==(IteratorInterface1 lhs, IteratorInterface2 rhs) noexcept(
         noexcept(detail::common_diff(lhs, rhs)))
         -> decltype(
-            v1_dtl::derived_iterator(lhs), detail::common_diff(lhs, rhs))
+            v1_dtl::derived_iterator(lhs), detail::common_diff(lhs, rhs) == 0)
     {
         return detail::common_diff(lhs, rhs) == 0;
     }
@@ -474,7 +474,7 @@ namespace boost { namespace stl_interfaces { inline namespace v1 {
     operator<(IteratorInterface1 lhs, IteratorInterface2 rhs) noexcept(
         noexcept(detail::common_diff(lhs, rhs)))
         -> decltype(
-            v1_dtl::derived_iterator(lhs), detail::common_diff(lhs, rhs))
+            v1_dtl::derived_iterator(lhs), detail::common_diff(lhs, rhs) < 0)
     {
         return detail::common_diff(lhs, rhs) < 0;
     }
@@ -487,7 +487,7 @@ namespace boost { namespace stl_interfaces { inline namespace v1 {
     operator<=(IteratorInterface1 lhs, IteratorInterface2 rhs) noexcept(
         noexcept(detail::common_diff(lhs, rhs)))
         -> decltype(
-            v1_dtl::derived_iterator(lhs), detail::common_diff(lhs, rhs))
+            v1_dtl::derived_iterator(lhs), detail::common_diff(lhs, rhs) <= 0)
     {
         return detail::common_diff(lhs, rhs) <= 0;
     }
@@ -500,7 +500,7 @@ namespace boost { namespace stl_interfaces { inline namespace v1 {
     operator>(IteratorInterface1 lhs, IteratorInterface2 rhs) noexcept(
         noexcept(detail::common_diff(lhs, rhs)))
         -> decltype(
-            v1_dtl::derived_iterator(lhs), detail::common_diff(lhs, rhs))
+            v1_dtl::derived_iterator(lhs), detail::common_diff(lhs, rhs) > 0)
     {
         return detail::common_diff(lhs, rhs) > 0;
     }
@@ -513,7 +513,7 @@ namespace boost { namespace stl_interfaces { inline namespace v1 {
     operator>=(IteratorInterface1 lhs, IteratorInterface2 rhs) noexcept(
         noexcept(detail::common_diff(lhs, rhs)))
         -> decltype(
-            v1_dtl::derived_iterator(lhs), detail::common_diff(lhs, rhs))
+            v1_dtl::derived_iterator(lhs), detail::common_diff(lhs, rhs) >= 0)
     {
         return detail::common_diff(lhs, rhs) >= 0;
     }


### PR DESCRIPTION
Even though implementation works fine, the current one deduces non-bool types, which doesn't play nice with gcc10-ranges implementation.